### PR TITLE
Adds compatibility with latest module versions

### DIFF
--- a/pydca/contact_visualizer/contact_visualizer.py
+++ b/pydca/contact_visualizer/contact_visualizer.py
@@ -1,11 +1,16 @@
 import matplotlib.pyplot as plt
 import Bio.PDB as biopdb
 import Bio.SeqIO
-from Bio.SubsMat.MatrixInfo import blosum62
-from Bio import pairwise2
+try:
+    from Bio.SubsMat.MatrixInfo import blosum62
+    from Bio import pairwise2
+except ImportError:
+    from Bio.Align import substitution_matrices
+    blosum62 = substitution_matrices.load("BLOSUM62")
 from argparse import ArgumentParser
 import logging
 from ..sequence_backmapper import scoring_matrix
+from ..sequence_backmapper.sequence_backmapper import local_align
 import os
 from collections import OrderedDict
 import itertools
@@ -1202,22 +1207,7 @@ class DCAVisualizer:
             self.__pdb_chain_id, pdb_seq)
         )
 
-        if self.__biomolecule == 'PROTEIN':
-            scoring_mat = blosum62
-            GAP_OPEN_PEN = -10
-            GAP_EXTEND_PEN = -1
-        if self.__biomolecule == 'RNA':
-            scoring_mat = scoring_matrix.NUC44
-            GAP_OPEN_PEN = -8
-            GAP_EXTEND_PEN = 0
-        alignment = pairwise2.align.localds(
-            ref_seq,
-            pdb_seq,
-            scoring_mat,
-            GAP_OPEN_PEN,
-            GAP_EXTEND_PEN,
-            score_only=False,
-        )
+        alignment = local_align(ref_seq, pdb_seq, self.__biomolecule)
         seq_ref_aligned = alignment[0][0]
         seq_pdb_aligned = alignment[0][1]
         alignment_starts_at = alignment[0][3]

--- a/pydca/fasta_reader/fasta_reader.py
+++ b/pydca/fasta_reader/fasta_reader.py
@@ -91,7 +91,10 @@ def get_alignment_from_fasta_file(file_name):
     """
     alignment = []
     try:
-        record_iterator = AlignIO.read(file_name, 'fasta')
+        try:
+            record_iterator = AlignIO.read(file_name, 'fasta-pearson')
+        except ValueError:
+            record_iterator = AlignIO.read(file_name, 'fasta')
         #biopython just reads the records if there are tags (>some key).
         #It doesn't know if the file is really a biological sequence or not
     except Exception as expt:

--- a/pydca/msa_trimmer/msa_trimmer.py
+++ b/pydca/msa_trimmer/msa_trimmer.py
@@ -36,7 +36,10 @@ class MSATrimmer:
             self.__biomolecule = biomolecule.strip().upper()
         else:
             self.__biomolecule = biomolecule
-        self.__alignment_data = list(AlignIO.read(self.__msa_file, 'fasta'))
+        try:
+            self.__alignment_data = list(AlignIO.read(self.__msa_file, 'fasta-pearson'))
+        except ValueError:
+            self.__alignment_data = list(AlignIO.read(self.__msa_file, 'fasta'))
 
         logger.info('\n\tMSA file: {0}'
             '\n\tReference sequence file: {1}'

--- a/pydca/sequence_backmapper/scoring_matrix.py
+++ b/pydca/sequence_backmapper/scoring_matrix.py
@@ -91,3 +91,9 @@ NUCLEOTIDE_AMBIGUOUS_SCORING = {
 }
 
 NUC44 = NUCLEOTIDE_NUCLEOTIDE_SCORING
+
+try:
+    from Bio.Align import substitution_matrices as _submat
+    NUC44_ARRAY = _submat.Array(data=NUC44)
+except ImportError:
+    NUC44_ARRAY = None

--- a/pydca/sequence_backmapper/sequence_backmapper.py
+++ b/pydca/sequence_backmapper/sequence_backmapper.py
@@ -1,9 +1,63 @@
 from pydca.fasta_reader import fasta_reader
 from . import scoring_matrix
-from Bio import pairwise2
-from Bio.SubsMat.MatrixInfo import blosum62
+try:
+    from Bio import pairwise2
+    from Bio.SubsMat.MatrixInfo import blosum62
+    _USE_PAIRWISE2 = True
+except ImportError:
+    from Bio.Align import PairwiseAligner, substitution_matrices
+    blosum62 = substitution_matrices.load("BLOSUM62")
+    _USE_PAIRWISE2 = False
 import logging
 import os
+
+
+def _get_scoring_params(biomolecule):
+    """Return (scoring_matrix, gap_open, gap_extend) for RNA or protein."""
+    if biomolecule == 'RNA':
+        if _USE_PAIRWISE2:
+            return scoring_matrix.NUC44, -8, 0
+        return scoring_matrix.NUC44_ARRAY, -8, 0
+    elif biomolecule == 'PROTEIN':
+        return blosum62, -10, -1
+    raise ValueError("Unknown biomolecule type: {!r}".format(biomolecule))
+
+
+def local_align(ref_seq, other_seq, biomolecule, score_only=False):
+    """Pairwise local alignment.
+
+    Returns the alignment score (float) if score_only is True.
+    Otherwise returns a list of (aligned_ref, aligned_other, score, start, end)
+    tuples matching the pairwise2 format that downstream code expects.
+    """
+    scoring_mat, gap_open, gap_extend = _get_scoring_params(biomolecule)
+
+    if _USE_PAIRWISE2:
+        return pairwise2.align.localds(
+            ref_seq, other_seq, scoring_mat,
+            gap_open, gap_extend, score_only=score_only,
+        )
+
+    aligner = PairwiseAligner()
+    aligner.mode = 'local'
+    aligner.substitution_matrix = scoring_mat
+    aligner.open_gap_score = gap_open
+    aligner.extend_gap_score = gap_extend
+
+    if score_only:
+        return aligner.score(ref_seq, other_seq)
+
+    results = []
+    for aln in aligner.align(ref_seq, other_seq):
+        #Complete gaps in the alignment
+        aligned_ref = aln[0]       
+        aligned_other = aln[1]     
+        ref_start = int(aln.aligned[0][0][0])   
+        ref_end = int(aln.aligned[0][-1][1])    
+        full_ref = ref_seq[:ref_start] + aligned_ref + ref_seq[ref_end:]
+        full_other = '-' * ref_start + aligned_other + '-' * (len(ref_seq) - ref_end)
+        results.append((full_ref, full_other, aln.score, ref_start, ref_start + len(aligned_ref)))
+    return results
 
 """Performs sequence back-mapping of a reference sequence to an MSA sequeces.
 The back-mapping is done by searching the best matching sequence to the reference.
@@ -203,29 +257,7 @@ class SequenceBackmapper:
                 A tuple of pairwise aligned sequences, alignment score and
                 start and end indices of alignment
         """
-        if self.__biomolecule == 'RNA':
-            scoring_mat = scoring_matrix.NUC44
-            GAP_OPEN_PEN = -8
-            GAP_EXTEND_PEN = 0
-        elif self.__biomolecule == 'PROTEIN':
-            scoring_mat = blosum62
-            GAP_OPEN_PEN = -10
-            GAP_EXTEND_PEN = -1
-        else:
-            logger.error('\n\tUnknown biomolecule type.'
-                ' Cannot figure out the scoring matrix.')
-            raise ValueError
-
-        alignments = pairwise2.align.localds(
-            ref_seq,
-            other_seq,
-            scoring_mat,
-            GAP_OPEN_PEN,
-            GAP_EXTEND_PEN,
-            score_only = score_only,
-        )
-
-        return alignments
+        return local_align(ref_seq, other_seq, self.__biomolecule, score_only=score_only)
 
 
     def find_matching_seqs_from_alignment(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-scipy==1.3.1
-biopython==1.74
-numpy>=1.13.3, <=1.15.4
-llvmlite==0.30.0
-numba==0.46.0
-matplotlib==3.0.0
+scipy
+biopython
+numpy
+llvmlite
+numba
+matplotlib
 requests>=2.22.0

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@ with open("README.md") as fh:
     long_description = fh.read()
 
 requirements = [
-    "scipy==1.3.1",
-    "biopython==1.74",
-    "numpy>=1.13.3, <=1.15.4",
-    'llvmlite==0.30.0',
-    "numba==0.46.0",
-    "matplotlib==3.0.0",
+    "scipy",
+    "biopython",
+    "numpy",
+    'llvmlite',
+    "numba",
+    "matplotlib",
     "requests>=2.22.0",
 ]
 


### PR DESCRIPTION
I try to do the minimal changes necessary to add compatibility of pydca with the latest modules. I tested it with python versions from 3.5 to 3.13 and checked that it preserves backward compatibility.

Changes:
- Changed the default `msa_file_format` parameter from `'fasta'` to  `'fasta-pearson'`.<https://github.com/biopython/biopython/blob/master/DEPRECATED.rst#bioseqiofastaio>
- Created a local_align function that uses `Bio.Pairwise.Aligner` when Bio.pairwise2 is not available. `PairwiseAligner` may not include gaps for unaligned segments at the beginning or end of the sequences, so padding was needed.
- Changed the location of substitution matrix for blosum62 from `Bio.SubsMat.MatrixInfo.blosum62` to  Bio.Align.substitution_matrices.load("BLOSUM62")
- Changed the location of substitution matrix for NUC44 from `Bio.Align.scoring_matrix.NUC44` to  `Bio.Align.scoring_matrix.NUC44_ARRAY`

Related issues:
- #9
- #10 
- #11
- #12